### PR TITLE
Remove minor version explicit information

### DIFF
--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -8,10 +8,6 @@ module Spree
       VERSION
     end
 
-    def self.minor_version
-      '3.0'
-    end
-
     def self.gem_version
       Gem::Version.new(version)
     end


### PR DESCRIPTION
The method is leftover after extracting solidus_frontend from the
mono-repo. It was introduced in
https://github.com/solidusio/solidus/pull/4087 to be used in the update
generator, but it's the business of solidus_core.