### PR TITLE
Bump version to 3.3.0.alpha

### DIFF
--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   module Frontend
-    VERSION = "3.2.0"
+    VERSION = "3.3.0.alpha"
 
     def self.version
       VERSION


### PR DESCRIPTION
We need it and we need it on RubyGems so that Solidus can run its test
suite