### PR TITLE
Add Solidus::Frontend::Search::Base

### DIFF
--- a/app/controllers/spree/store_controller.rb
+++ b/app/controllers/spree/store_controller.rb
@@ -4,6 +4,7 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Pricing
     include Spree::Core::ControllerHelpers::Order
+    include Spree::Frontend::ControllerHelpers::Search
 
     def unauthorized
       render 'spree/shared/unauthorized', layout: Spree::Config[:layout], status: 401

--- a/lib/spree/frontend.rb
+++ b/lib/spree/frontend.rb
@@ -12,3 +12,4 @@ require 'kaminari'
 
 require 'spree/frontend/middleware/seo_assist'
 require 'spree/frontend/engine'
+require 'spree/frontend/controller_helpers/search'

--- a/lib/spree/frontend/controller_helpers/search.rb
+++ b/lib/spree/frontend/controller_helpers/search.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Spree
+  module Frontend
+    module ControllerHelpers
+      module Search
+        def build_searcher(params)
+          Spree::Frontend::Config.searcher_class.new(params).tap do |searcher|
+            searcher.current_user = spree_current_user
+            searcher.pricing_options = current_pricing_options
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/frontend/search/base.rb
+++ b/lib/spree/frontend/search/base.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Spree
+  module Frontend
+    module Search
+      class Base
+        attr_accessor :properties
+        attr_accessor :current_user
+        attr_accessor :pricing_options
+
+        def initialize(params)
+          self.pricing_options = Spree::Config.default_pricing_options
+          @properties = {}
+          prepare(params)
+        end
+
+        def retrieve_products
+          @products = get_base_scope
+          curr_page = @properties[:page] || 1
+
+          unless Spree::Frontend::Config.show_products_without_price
+            @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.search_arguments)).distinct
+          end
+          @products = @products.page(curr_page).per(@properties[:per_page])
+        end
+
+        protected
+
+        def get_base_scope
+          base_scope = Spree::Product.display_includes.available
+          base_scope = base_scope.in_taxon(@properties[:taxon]) unless @properties[:taxon].blank?
+          base_scope = get_products_conditions_for(base_scope, @properties[:keywords])
+          base_scope = add_search_scopes(base_scope)
+          base_scope = add_eagerload_scopes(base_scope)
+          base_scope
+        end
+
+        def add_eagerload_scopes(scope)
+          # TL;DR Switch from `preload` to `includes` as soon as Rails starts honoring
+          # `order` clauses on `has_many` associations when a `where` constraint
+          # affecting a joined table is present (see
+          # https://github.com/rails/rails/issues/6769).
+          #
+          # Ideally this would use `includes` instead of `preload` calls, leaving it
+          # up to Rails whether associated objects should be fetched in one big join
+          # or multiple independent queries. However as of Rails 4.1.8 any `order`
+          # defined on `has_many` associations are ignored when Rails builds a join
+          # query.
+          #
+          # Would we use `includes` in this particular case, Rails would do
+          # separate queries most of the time but opt for a join as soon as any
+          # `where` constraints affecting joined tables are added to the search;
+          # which is the case as soon as a taxon is added to the base scope.
+          scope = scope.preload(master: :prices)
+          scope = scope.preload(master: :images) if @properties[:include_images]
+          scope
+        end
+
+        def add_search_scopes(base_scope)
+          if @properties[:search]
+            @properties[:search].each do |name, scope_attribute|
+              scope_name = name.to_sym
+              if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
+                base_scope = base_scope.send(scope_name, *scope_attribute)
+              else
+                base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
+              end
+            end
+          end
+          base_scope
+        end
+
+        # method should return new scope based on base_scope
+        def get_products_conditions_for(base_scope, query)
+          unless query.blank?
+            base_scope = base_scope.like_any([:name, :description], query.split)
+          end
+          base_scope
+        end
+
+        def prepare(params)
+          @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
+          @properties[:keywords] = params[:keywords]
+          @properties[:search] = params[:search]
+          @properties[:include_images] = params[:include_images]
+
+          per_page = params[:per_page].to_i
+          @properties[:per_page] = per_page > 0 ? per_page : Spree::Frontend::Config[:products_per_page]
+          @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/frontend_configuration.rb
+++ b/lib/spree/frontend_configuration.rb
@@ -1,10 +1,22 @@
 # frozen_string_literal: true
 
+require 'spree/frontend/search/base'
+
 module Spree
   class FrontendConfiguration < Preferences::Configuration
     preference :locale, :string, default: I18n.default_locale
 
     # Add your terms and conditions in app/views/spree/checkout/_terms_and_conditions.en.html.erb
     preference :require_terms_and_conditions_acceptance, :boolean, default: false
+
+    # @!attribute [rw] products_per_page
+    #   @return [Integer] Products to show per-page in the frontend (default: +12+)
+    preference :products_per_page, :integer, default: 12
+
+    # @!attribute [rw] show_products_without_price
+    #   @return [Boolean] Whether products without a price are visible in the frontend (default: +false+)
+    preference :show_products_without_price, :boolean, default: false
+
+    class_name_attribute :searcher_class, default: 'Spree::Frontend::Search::Base'
   end
 end

--- a/spec/controllers/spree/home_controller_spec.rb
+++ b/spec/controllers/spree/home_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::HomeController, type: :controller do
   it "provides current user to the searcher class" do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages spree_current_user: user
-    expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
+    expect_any_instance_of(Spree::Frontend::Config.searcher_class).to receive(:current_user=).with(user)
     get :index
     expect(response.status).to eq(200)
   end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -21,7 +21,7 @@ describe Spree::ProductsController, type: :controller do
   it "should provide the current user to the searcher class" do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages spree_current_user: user
-    expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
+    expect_any_instance_of(Spree::Frontend::Config.searcher_class).to receive(:current_user=).with(user)
     get :index
     expect(response.status).to eq(200)
   end

--- a/spec/controllers/spree/taxons_controller_spec.rb
+++ b/spec/controllers/spree/taxons_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::TaxonsController, type: :controller do
     taxon = create(:taxon, permalink: "test")
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages spree_current_user: user
-    expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
+    expect_any_instance_of(Spree::Frontend::Config.searcher_class).to receive(:current_user=).with(user)
     get :show, params: { id: taxon.permalink }
     expect(response.status).to eq(200)
   end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -221,7 +221,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     visit spree.root_path
 
     expect(page.all('ul.product-listing li').size).to eq(9)
-    stub_spree_preferences(show_products_without_price: false)
+    stub_spree_preferences(Spree::Frontend::Config, show_products_without_price: false)
     stub_spree_preferences(currency: "CAN")
     visit spree.root_path
     expect(page.all('ul.product-listing li').size).to eq(0)
@@ -252,7 +252,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   it "should be able to display products priced between 15 and 18 dollars across multiple pages" do
     visit spree.root_path
 
-    stub_spree_preferences(products_per_page: 2)
+    stub_spree_preferences(Spree::Frontend::Config, products_per_page: 2)
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$15.00_-_$18.00"
     within(:css, '#sidebar_products_search') { click_button "Search" }
@@ -298,7 +298,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
     product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
     stub_spree_preferences(currency: "CAN")
-    stub_spree_preferences(show_products_without_price: true)
+    stub_spree_preferences(Spree::Frontend::Config, show_products_without_price: true)
     visit spree.product_path(product)
     expect(page).to have_content "This product is not available in the selected currency."
     expect(page).not_to have_content "add-to-cart-button"
@@ -309,7 +309,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
     product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
     stub_spree_preferences(currency: "CAN")
-    stub_spree_preferences(show_products_without_price: true)
+    stub_spree_preferences(Spree::Frontend::Config, show_products_without_price: true)
     visit spree.products_path
     expect(page).to have_content(product.name)
   end

--- a/spec/lib/spree/controller_helpers/search_spec.rb
+++ b/spec/lib/spree/controller_helpers/search_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Frontend::ControllerHelpers::Search, type: :controller do
+  controller(ApplicationController) {
+    include Spree::Core::ControllerHelpers::Auth
+    include Spree::Core::ControllerHelpers::Pricing
+    include Spree::Frontend::ControllerHelpers::Search
+  }
+
+  describe '#build_searcher' do
+    it 'returns Spree::Core::Search::Base instance' do
+      allow(controller).to receive_messages(
+        spree_current_user: create(:user),
+        current_pricing_options: Spree::Config.pricing_options_class.new(currency: 'USD')
+      )
+      expect(controller.build_searcher({}).class).to eq Spree::Frontend::Search::Base
+    end
+  end
+end

--- a/spec/lib/spree/frontend/search/base_spec.rb
+++ b/spec/lib/spree/frontend/search/base_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/core/product_filters'
+
+RSpec.describe Spree::Frontend::Search::Base do
+  before do
+    include Spree::Core::ProductFilters
+    @taxon = create(:taxon, name: "Ruby on Rails")
+
+    @product1 = create(:product, name: "RoR Mug", price: 9.00)
+    @product1.taxons << @taxon
+    @product2 = create(:product, name: "RoR Shirt", price: 11.00)
+    @product3 = create(:product, name: "RoR Pants", price: 16.00)
+  end
+
+  it "returns all products by default" do
+    params = { per_page: "" }
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(3)
+  end
+
+  context "when include_images is included in the initialization params" do
+    let(:params) { { include_images: true, keyword: @product1.name, taxon: @taxon.id } }
+    let(:image_file) { open_image('blank.jpg') }
+    subject { described_class.new(params).retrieve_products }
+
+    before do
+      @product1.master.images.create(attachment_file_name: 'test', attachment: image_file, position: 2)
+      @product1.master.images.create(attachment_file_name: 'test1', attachment: image_file, position: 1)
+      @product1.reload
+    end
+
+    it "returns images in correct order" do
+      expect(subject.first).to eq @product1
+      expect(subject.first.images).to eq @product1.master.images
+    end
+  end
+
+  context "when ascend_by_master_price scope is included in the initialization params" do
+    let(:params) { { search: { ascend_by_master_price: nil } } }
+
+    subject { described_class.new(params).retrieve_products }
+
+    it "returns products in ascending order" do
+      expect(subject.map { |product| product.price.to_i }).to eq [9, 11, 16]
+    end
+  end
+
+  context "when descend_by_master_price scope is included in the initialization params" do
+    let(:params) { { search: { descend_by_master_price: nil } } }
+
+    subject { described_class.new(params).retrieve_products }
+
+    it "returns products in descending order" do
+      expect(subject.map { |product| product.price.to_i }).to eq [16, 11, 9]
+    end
+  end
+
+  it "switches to next page according to the page parameter" do
+    params = { per_page: "2" }
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(2)
+
+    params[:page] = "2"
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(1)
+  end
+
+  it "maps search params to named scopes" do
+    params = { per_page: "",
+               search: { "price_range_any" => ["Under $10.00"] } }
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(1)
+  end
+
+  it "maps multiple price_range_any filters" do
+    params = { per_page: "",
+               search: { "price_range_any" => ["Under $10.00", "$10.00 - $15.00"] } }
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(2)
+  end
+
+  it "uses ransack if scope not found" do
+    params = { per_page: "",
+               search: { "name_not_cont" => "Shirt" } }
+    searcher = Spree::Frontend::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(2)
+  end
+
+  it "accepts a current user" do
+    user = double
+    searcher = Spree::Frontend::Search::Base.new({})
+    searcher.current_user = user
+    expect(searcher.current_user).to eql(user)
+  end
+
+  it "finds products in alternate currencies" do
+    create(:price, currency: 'EUR', variant: @product1.master)
+    searcher = Spree::Frontend::Search::Base.new({})
+    searcher.pricing_options = Spree::Config.pricing_options_class.new(currency: 'EUR')
+    expect(searcher.retrieve_products).to eq([@product1])
+  end
+
+  def open_image(image)
+    File.open(
+      File.join(
+        Spree::Core::Engine.root, 'lib', 'spree', 'testing_support', 'fixtures', image
+        )
+      )
+  end
+end


### PR DESCRIPTION
Solidus' Search Base is currently only utilized by the front end. Therefore it would make sense to move the related class, preferences, and module into this gem. This PR is part 1 of 3 steps:

1. [Move related class/preferences/modules to solidus_frontend](https://github.com/solidusio/solidus_frontend/pull/7)
2. [Deprecate Solidus::Core::Search::Base, Solidus::Core::ControllerHelpers::Search, and related preferences on the solidus gem](https://github.com/solidusio/solidus/pull/4527)
3. Remove Solidus::Core::Search::Base, Solidus::Core::ControllerHelpers::Search, and related preferences from solidus

The structure was kept the same except for namespacing!