### PR TITLE
Fix display of tax adjustments in checkout

### DIFF
--- a/app/views/spree/checkout/_summary.html.erb
+++ b/app/views/spree/checkout/_summary.html.erb
@@ -45,10 +45,9 @@
       <% end %>
     <% end %>
 
-    <% if order.adjustments.nonzero.eligible.exists? %>
+    <% if order.adjustments.nonzero.non_tax.eligible.exists? %>
       <tbody id="summary-order-charges" data-hook>
-        <% order.adjustments.nonzero.eligible.each do |adjustment| %>
-        <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
+        <% order.adjustments.nonzero.non_tax.eligible.each do |adjustment| %>
           <tr class="total">
             <td><%= adjustment.label %>:</td>
             <td><%= adjustment.display_amount.to_html %></td>


### PR DESCRIPTION
## Description
We loop through `order.all_adjustments.tax` just above this block. Which means there's no need to print out those tax adjustments a second time here.

This has been broken for ~9 years now I think. However, it's largely gone unnoticed because we haven't had any order-level tax adjustments for quite a while. Now that we've got a new order-level tax coming (solidusio/solidus#4491) we should fix this.

## How Has This Been Tested?
Tested locally in a sandbox app.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
