### PR TITLE
Skip trying to install solidus_bolt when there's no Gemfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-skip_solidus_bolt: &skip_solidus_bolt
-  environment:
-    SKIP_SOLIDUS_BOLT: 1
-
 orbs:
   browser-tools: circleci/browser-tools@1.3
 
@@ -22,7 +18,6 @@ commands:
 
 jobs:
   run-specs-with-postgres:
-    <<: *skip_solidus_bolt
     executor: solidusio_extensions/postgres
     steps:
       - checkout
@@ -32,7 +27,6 @@ jobs:
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
   run-specs-with-mysql:
-    <<: *skip_solidus_bolt
     executor: solidusio_extensions/mysql
     steps:
       - checkout

--- a/lib/generators/solidus_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_frontend/install/install_generator.rb
@@ -25,7 +25,7 @@ module SolidusFrontend
       end
 
       def install_solidus_bolt
-        return if ENV['SKIP_SOLIDUS_BOLT'] || !(options[:auto_accept] || yes?(<<~MSG))
+        return if ENV['SKIP_SOLIDUS_BOLT'] || !File.exist?('Gemfile') || !(options[:auto_accept] || yes?(<<~MSG))
           Would you like to add bolt (https://www.bolt.com) as a default payment method?
 
           If you answer yes, solidus_bolt (https://github.com/solidusio/solidus_bolt)


### PR DESCRIPTION
The dummy application generated within the extensions test suite [lacks the Gemfile](https://github.com/solidusio/solidus/blob/bdebdbc15457487ab412702a02980bbbe32d3a6e/core/lib/generators/spree/dummy/dummy_generator.rb#L36). We want to skip trying to install solidus_bolt in those cases, as otherwise, it fails.

We keep the SKIP_SOLIDUS_BOLT environment variable behavior as that's still useful to skip bolt when there's a Gemfile (i.e., when creating a sandbox app). However, it can be removed from CI.