### PR TITLE
Handle robots in here

### DIFF
--- a/lib/generators/solidus_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_frontend/install/install_generator.rb
@@ -13,6 +13,19 @@ module SolidusFrontend
         template 'initializer.rb', 'config/initializers/solidus_frontend.rb'
       end
 
+      def robots_directives
+        append_file "public/robots.txt", <<-ROBOTS.strip_heredoc
+          User-agent: *
+          Disallow: /checkout
+          Disallow: /cart
+          Disallow: /orders
+          Disallow: /user
+          Disallow: /account
+          Disallow: /api
+          Disallow: /password
+        ROBOTS
+      end
+
       def setup_assets
         empty_directory 'app/assets/images'
 


### PR DESCRIPTION
This was previously added by `solidus:install` but having to do with frontend routes it's better to handle it here.

The fact that `solidus:install` will keep appending these lines is not an issue as Thor's behavior won't append anything if it's already there.