### PR TITLE
Touch the robots file before appending to it

### DIFF
--- a/lib/generators/solidus_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_frontend/install/install_generator.rb
@@ -14,6 +14,7 @@ module SolidusFrontend
       end
 
       def robots_directives
+        FileUtils.touch "public/robots.txt"
         append_file "public/robots.txt", <<-ROBOTS.strip_heredoc
           User-agent: *
           Disallow: /checkout

--- a/lib/generators/solidus_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_frontend/install/install_generator.rb
@@ -9,6 +9,10 @@ module SolidusFrontend
                    type: :boolean,
                    default: false
 
+      def self.exit_on_failure?
+        true
+      end
+
       def copy_initializer
         template 'initializer.rb', 'config/initializers/solidus_frontend.rb'
       end


### PR DESCRIPTION
I the file is missing (e.g. in the dummy app) this fails silently, unless `self.exit_on_failure?` returns true when called from another generator.
