### PR TITLE
[v3.2] Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3
+  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -16,6 +17,13 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: master, v[0-9]+\.[0-9]+
+
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
@@ -26,6 +34,7 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+      - notify
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
@@ -35,16 +44,20 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+      - notify
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
       - solidusio_extensions/lint-code
+      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets
 
   "Weekly run specs against master":
     triggers:
@@ -55,5 +68,7 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets


### PR DESCRIPTION
## Summary

Backports #24 to v3.2

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. We only track builds on main and branches tracking old Solidus releases. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2) channel on [Solidus' Slack workspace (https://solidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202761161-c405a031-1277-407b-b721-0a9bc68e4acc.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~

