### PR TITLE
Fix CircleCI errors due to libvips not being found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ commands:
     steps:
       - run:
           name: Install libvips
-          command: sudo apt-get install -y libvips
+          command: |
+            sudo apt-get update
+            sudo apt-get install -yq libvips-dev
 
   notify:
     steps:


### PR DESCRIPTION
## Summary

Previously, `libvips` was resolved to `libvips42`. However, only using `libvips42` will make some tests fail. To get rid of the errors, we need to add `libvips-dev` (which also relies on the latter).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
