### PR TITLE
Remove Slack notifications for CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3
-  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -19,13 +18,6 @@ commands:
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
 
-  notify:
-    steps:
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-          branch_pattern: master, v[0-9]+\.[0-9]+
-
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
@@ -36,7 +28,6 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
-      - notify
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
@@ -46,20 +37,16 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
-      - notify
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
       - solidusio_extensions/lint-code
-      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql
 
   "Weekly run specs against master":
     triggers:
@@ -70,7 +57,5 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql


### PR DESCRIPTION
## Summary

We were storing the Slack secrets on a [CircleCI context](https://circleci.com/docs/contexts/). Although we were also [passing them to forks](https://circleci.com/docs/oss/#pass-secrets-to-builds-from-forked-pull-requests), it resulted on unauthorized builds for external contributions.

We could work around the issue in two ways:

- Having the secrets outside of any context, but that would compromise the security of the associated Slack channel for:
  - Send messages as @<!---->CircleCI notifications
  - Send messages to channels @<!---->CircleCI notifications isn't a member of
  - Upload, edit, and delete files as CircleCI notifications
- Using CircleCI [logic statements](https://circleci.com/docs/configuration-reference/#logic-statements) to conditionally run jobs when `CIRCLECI_USERNAME` or `CIRCLE_PR_USERNAME` [env vars](https://circleci.com/docs/variables/) are in a list of allowed users. However, that would be something difficult to maintain, and there's no other way to check the user's role.

Given that we don't find those trade-offs to be acceptable, we remove the integration for now.

Closes #4902

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
