### PR TITLE
Add changes from main to v4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,34 +19,38 @@ commands:
             sudo apt-get install -yq libvips-dev
 
 jobs:
-  run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+  run-specs:
+    parameters:
+      db:
+        type: string
+        default: "postgres"
+      ruby:
+        type: string
+        default: "3.2"
+    executor:
+      name: solidusio_extensions/<< parameters.db >>
+      ruby_version: << parameters.ruby >>
     steps:
       - checkout
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - libvips
       - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-  run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
-    steps:
-      - checkout
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
-      - libvips
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-  lint-code:
-    executor: solidusio_extensions/sqlite-memory
-    steps:
-      - solidusio_extensions/lint-code
 
 workflows:
-  "Run specs on supported Solidus versions":
+  "Run specs on Solidus master":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs:
+          name: &name "run-specs-solidus-master-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: &name "run-specs-solidus-master-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { ruby: ["3.1"], db: ["mysql"] }
+      - run-specs:
+          name: &name "run-specs-solidus-master-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { ruby: ["3.0"], db: ["sqlite"] }
 
   "Weekly run specs against master":
     triggers:
@@ -57,5 +61,7 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { ruby: ["3.2"], db: ["postgres"] }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ commands:
     steps:
       - run:
           name: Install libvips
-          command: sudo apt-get install -y libvips
+          command: |
+            sudo apt-get update
+            sudo apt-get install -yq libvips-dev
 
   notify:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3
+  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -16,6 +17,13 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: master, v[0-9]+\.[0-9]+
+
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
@@ -26,6 +34,7 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+      - notify
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
@@ -35,16 +44,20 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+      - notify
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
       - solidusio_extensions/lint-code
+      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets
 
   "Weekly run specs against master":
     triggers:
@@ -55,5 +68,7 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3
-  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -19,13 +18,6 @@ commands:
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
 
-  notify:
-    steps:
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-          branch_pattern: master, v[0-9]+\.[0-9]+
-
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
@@ -36,7 +28,6 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
-      - notify
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
@@ -46,20 +37,16 @@ jobs:
       - libvips
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
-      - notify
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
       - solidusio_extensions/lint-code
-      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql
 
   "Weekly run specs against master":
     triggers:
@@ -70,7 +57,5 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,1 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: false
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - pinned
-  - security
-# Label to use when marking an issue as stale
-staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It might be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+_extends: .github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,33 @@
 # Changelog
 
-## Solidus 3.2.5 (v3.2, 2022-12-23)
+## Solidus v3.3.0 (v3.3, 2023-01-24)
 
-## Solidus 3.2.4 (v3.2, 2022-11-09)
+- Fix CircleCI errors due to libvips not being found [#27](https://github.com/solidusio/solidus_frontend/pull/27) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Update Changelog with latest released versions [#26](https://github.com/solidusio/solidus_frontend/pull/26) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- [v3.2] Notify CI failures on Slack [#25](https://github.com/solidusio/solidus_frontend/pull/25) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Notify CI failures on Slack [#24](https://github.com/solidusio/solidus_frontend/pull/24) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Touch the robots file before appending to it [#18](https://github.com/solidusio/solidus_frontend/pull/18) ([elia](https://github.com/elia))
+- Handle robots in here [#17](https://github.com/solidusio/solidus_frontend/pull/17) ([elia](https://github.com/elia))
+- [v3.2] Skip trying to install solidus_bolt when there's no Gemfile [#16](https://github.com/solidusio/solidus_frontend/pull/16) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Skip trying to install solidus_bolt when there's no Gemfile [#15](https://github.com/solidusio/solidus_frontend/pull/15) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Ask whether to add solidus_bolt during installation [#14](https://github.com/solidusio/solidus_frontend/pull/14) ([waiting-for-dev](https://github.com/waiting-for-dev))
+- Fix display of tax adjustments in checkout [#11](https://github.com/solidusio/solidus_frontend/pull/11) ([adammathys](https://github.com/adammathys))
+- Utilize Rails redirect methods [#9](https://github.com/solidusio/solidus_frontend/pull/9) ([cpfergus1](https://github.com/cpfergus1))
+- Bump version to 3.3.0.alpha [#6](https://github.com/solidusio/solidus_frontend/pull/6) ([waiting-for-dev](https://github.com/waiting-for-dev))
 
-## Solidus 3.2.3 (v3.2, 2022-11-03)
+## Solidus v3.2.5 (v3.2, 2022-12-23)
 
-## Solidus 3.2.2 (v3.2, 2022-09-09)
+## Solidus v3.2.4 (v3.2, 2022-11-09)
+
+## Solidus v3.2.3 (v3.2, 2022-11-03)
+
+## Solidus v3.2.2 (v3.2, 2022-09-09)
 
 -  Ask whether to add solidus_bolt during installation [#14](https://github.com/solidusio/solidus_frontend/pull/14) ([waiting-for-dev](https://github.com/waiting-for-dev))
 
-## Solidus 3.2.1 (v3.2, 2022-09-09)
+## Solidus v3.2.1 (v3.2, 2022-09-09)
 
-## Solidus 3.2.0 (v3.2, 2022-08-18)
+## Solidus v3.2.0 (v3.2, 2022-08-18)
 
 - Initial release from the standalone repository. See [Solidus'
   CHANGELOG](https://github.com/solidusio/solidus/blob/master/CHANGELOG.md) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Solidus v3.4.0 (v3.4, 2023-04-21)
+
 ## Solidus v3.3.0 (v3.3, 2023-01-24)
 
 - Fix CircleCI errors due to libvips not being found [#27](https://github.com/solidusio/solidus_frontend/pull/27) ([waiting-for-dev](https://github.com/waiting-for-dev))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Solidus 3.2.5 (v3.2, 2022-12-23)
+
+## Solidus 3.2.4 (v3.2, 2022-11-09)
+
+## Solidus 3.2.3 (v3.2, 2022-11-03)
+
 ## Solidus 3.2.2 (v3.2, 2022-09-09)
 
 -  Ask whether to add solidus_bolt during installation [#14](https://github.com/solidusio/solidus_frontend/pull/14) ([waiting-for-dev](https://github.com/waiting-for-dev))

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 
 git "https://github.com/solidusio/solidus.git", branch: branch do
   gem 'solidus_api'

--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 Frontend contains controllers and views implementing a storefront and cart for Solidus.
 
-## Warning
+## 🚧 Warning
+
+This gem is deprecated and no longer part of the Solidus recommended stack.
 
 For new Solidus apps, we recommend that you use
 [SolidusStarterFrontend](https://github.com/solidusio/solidus_starter_frontend)
 instead.
+
+This repository will only accept bug fixes and security patches for the
+branches that match supported versions of Solidus:
+
+| Branch                                                          | End of Life |
+| --------------------------------------------------------------- | ----------- |
+| [v3.4](https://github.com/solidusio/solidus_frontend/tree/v3.4) | 2024-10-21  |
+| [v3.3](https://github.com/solidusio/solidus_frontend/tree/v3.3) | 2024-07-24  |
+| [v3.2](https://github.com/solidusio/solidus_frontend/tree/v3.2) | 2024-02-18  |
 
 ## Override views
 

--- a/lib/generators/solidus_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_frontend/install/install_generator.rb
@@ -9,11 +9,16 @@ module SolidusFrontend
                    type: :boolean,
                    default: false
 
+      def self.exit_on_failure?
+        true
+      end
+
       def copy_initializer
         template 'initializer.rb', 'config/initializers/solidus_frontend.rb'
       end
 
       def robots_directives
+        FileUtils.touch "public/robots.txt"
         append_file "public/robots.txt", <<-ROBOTS.strip_heredoc
           User-agent: *
           Disallow: /checkout

--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   module Frontend
-    VERSION = "3.3.0.alpha"
+    VERSION = "3.3.0"
 
     def self.version
       VERSION

--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   module Frontend
-    VERSION = "3.4.0.dev"
+    VERSION = "3.4.0"
 
     def self.version
       VERSION

--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   module Frontend
-    VERSION = "3.4.0"
+    VERSION = "4.0.0.dev"
 
     def self.version
       VERSION

--- a/lib/spree/frontend/version.rb
+++ b/lib/spree/frontend/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   module Frontend
-    VERSION = "3.3.0"
+    VERSION = "3.4.0.dev"
 
     def self.version
       VERSION

--- a/spec/helpers/base_helper_spec.rb
+++ b/spec/helpers/base_helper_spec.rb
@@ -6,8 +6,9 @@ module Spree
   describe BaseHelper, type: :helper do
     # Regression test for https://github.com/spree/spree/issues/2759
     it "nested_taxons_path works with a Taxon object" do
-      taxon = create(:taxon, name: "iphone")
-      expect(spree.nested_taxons_path(taxon)).to eq("/t/iphone")
+      taxonomy = create(:taxonomy, name: "smartphones")
+      taxon = create(:taxon, name: "iphone", taxonomy: taxonomy)
+      expect(spree.nested_taxons_path(taxon)).to eq("/t/smartphones/iphone")
     end
   end
 end


### PR DESCRIPTION
## Summary

I'm having an issue with updating solidus_multi_domain to work with Solidus 4. Specs are failing when I try to run specs on solidus v4.0. I'm not sure of the exact cause of the error but it seems to be because solidus_frontend v4.0 is a little bit behind. solidus_frontend v3.4 is up to date with main but it seems like 4.0 didn't get updated.